### PR TITLE
Add bobeckert.com white-label GitHub templates

### DIFF
--- a/github/repo-hygiene-whitelabel/bobeckert.com/.github/ISSUE_TEMPLATE/config.yml
+++ b/github/repo-hygiene-whitelabel/bobeckert.com/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: General project context
+    url: https://github.com/bobeckert/bobeckert.com/blob/main/README.md
+    about: Read the repo overview before filing broad or context-heavy requests.

--- a/github/repo-hygiene-whitelabel/bobeckert.com/.github/ISSUE_TEMPLATE/issue-submission.yml
+++ b/github/repo-hygiene-whitelabel/bobeckert.com/.github/ISSUE_TEMPLATE/issue-submission.yml
@@ -1,0 +1,93 @@
+name: Issue submission
+description: File a structured issue for content, design, UX, SEO, analytics, or site bugs.
+title: "[Issue]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing this. Please give enough context that someone can act on it without a long back-and-forth.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: What needs attention?
+      description: A short description of the problem, request, or idea.
+      placeholder: The homepage CTA is unclear and should point visitors toward one primary next action.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: issue_type
+    attributes:
+      label: Issue type
+      description: Pick the closest fit.
+      options:
+        - Content update
+        - Design / layout
+        - Bug / broken behavior
+        - SEO / search visibility
+        - Analytics / tracking
+        - Feature request
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: page_url
+    attributes:
+      label: Affected page or file
+      description: Link the page URL or name the repo file/path if known.
+      placeholder: https://bobeckert.com/ or index.html
+    validations:
+      required: true
+
+  - type: textarea
+    id: current_state
+    attributes:
+      label: What is happening now?
+      description: Describe the current behavior, content, or experience.
+      placeholder: Visitors land on the page, but the call to action is buried below the fold.
+    validations:
+      required: true
+
+  - type: textarea
+    id: desired_state
+    attributes:
+      label: What should happen instead?
+      description: Describe the expected outcome.
+      placeholder: The hero should clearly direct visitors to booking, consulting, or another primary action.
+    validations:
+      required: true
+
+  - type: textarea
+    id: supporting_context
+    attributes:
+      label: Supporting context
+      description: Add screenshots, references, notes, affected audience, or related links.
+      placeholder: Include any examples, copy ideas, analytics notes, or linked issues.
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance criteria
+      description: How will we know this issue is complete?
+      placeholder: |
+        - The CTA is visible without scrolling on desktop
+        - The button links to the correct destination
+        - Copy matches the approved tone
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - Nice to have
+        - Useful soon
+        - Important
+        - Urgent
+    validations:
+      required: true

--- a/github/repo-hygiene-whitelabel/bobeckert.com/.github/pull_request_template.md
+++ b/github/repo-hygiene-whitelabel/bobeckert.com/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## Summary
+- Briefly describe the change
+- Explain the main user/repo impact
+
+## Related
+- Closes #
+- Related issues, decisions, or follow-ups
+
+## Testing
+- [ ] Self-reviewed changed files
+- [ ] Relevant links/paths still work
+- [ ] Checks pass (if applicable)
+- [ ] Added or updated tests when practical
+
+## Review Notes
+- Any risk areas, rollout notes, or specific feedback requests

--- a/github/repo-hygiene-whitelabel/bobeckert.com/README.md
+++ b/github/repo-hygiene-whitelabel/bobeckert.com/README.md
@@ -1,0 +1,21 @@
+# bobeckert.com white-label GitHub templates
+
+This folder is the first white-label copy of the standardized repo-hygiene templates.
+
+## Included files
+- `.github/ISSUE_TEMPLATE/config.yml`
+- `.github/ISSUE_TEMPLATE/issue-submission.yml`
+- `.github/pull_request_template.md`
+
+## What stays standardized
+- Required sections and order
+- Review/testing checklist shape
+- Structured issue fields and workflow expectations
+
+## What is repo-specific here
+- Repo/property references
+- Project-context contact link
+- Example copy and framing text tuned to `bobeckert.com`
+
+## Source
+- `bobeckert/bobeckert.com`

--- a/github/repo-hygiene-whitelabel/bobgpt.com/.github/ISSUE_TEMPLATE/config.yml
+++ b/github/repo-hygiene-whitelabel/bobgpt.com/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: General project context
+    url: https://github.com/TwoHoundStudios/bobgpt.com/blob/main/README.md
+    about: Read the repo overview before filing broad or context-heavy requests.

--- a/github/repo-hygiene-whitelabel/bobgpt.com/.github/ISSUE_TEMPLATE/issue-submission.yml
+++ b/github/repo-hygiene-whitelabel/bobgpt.com/.github/ISSUE_TEMPLATE/issue-submission.yml
@@ -1,0 +1,94 @@
+name: Issue submission
+description: File a structured issue for BobGPT content, UX, infrastructure, or site bugs.
+title: "[Issue]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing this. Please give enough context that someone can act on it without a long back-and-forth.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: What needs attention?
+      description: A short description of the problem, request, or idea.
+      placeholder: The placeholder site needs a clearer next step or the Pages/domain setup is missing a required piece.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: issue_type
+    attributes:
+      label: Issue type
+      description: Pick the closest fit.
+      options:
+        - Content update
+        - Design / layout
+        - Bug / broken behavior
+        - SEO / search visibility
+        - Analytics / tracking
+        - Infrastructure / deployment
+        - Feature request
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: page_url
+    attributes:
+      label: Affected page or file
+      description: Link the page URL or name the repo file/path if known.
+      placeholder: https://bobgpt.com/ or index.html
+    validations:
+      required: true
+
+  - type: textarea
+    id: current_state
+    attributes:
+      label: What is happening now?
+      description: Describe the current behavior, content, or experience.
+      placeholder: The domain does not resolve, the content is incomplete, or the page behavior does not match expectations.
+    validations:
+      required: true
+
+  - type: textarea
+    id: desired_state
+    attributes:
+      label: What should happen instead?
+      description: Describe the expected outcome.
+      placeholder: The site should present the intended BobGPT direction clearly and the deployment path should work end to end.
+    validations:
+      required: true
+
+  - type: textarea
+    id: supporting_context
+    attributes:
+      label: Supporting context
+      description: Add screenshots, references, notes, audience context, or related links.
+      placeholder: Include examples, copy ideas, deployment notes, or linked issues.
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance criteria
+      description: How will we know this issue is complete?
+      placeholder: |
+        - The requested change is visible in the intended place
+        - Links and copy are correct
+        - The deployment or domain behavior matches the intended standard
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - Nice to have
+        - Useful soon
+        - Important
+        - Urgent
+    validations:
+      required: true

--- a/github/repo-hygiene-whitelabel/bobgpt.com/.github/pull_request_template.md
+++ b/github/repo-hygiene-whitelabel/bobgpt.com/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## Summary
+- What changed?
+- Why was this change needed?
+
+## Testing / verification
+- [ ] I verified the change locally or in preview as appropriate
+- [ ] I captured the relevant evidence in the linked issue or PR body
+
+## Linked issue
+- Closes #3
+
+## Checklist
+- [ ] Scope stays tight to the linked issue
+- [ ] Copy, links, and paths were checked
+- [ ] No secrets or unrelated changes were introduced
+- [ ] Bob review/approval is still required before merge

--- a/github/repo-hygiene-whitelabel/bobgpt.com/README.md
+++ b/github/repo-hygiene-whitelabel/bobgpt.com/README.md
@@ -1,0 +1,23 @@
+# bobgpt.com white-label GitHub templates
+
+This folder is a white-label copy of the standardized repo-hygiene templates for 
+auto-generated repo context: - source repo: 
+auto-fill below manually if needed.
+
+## Included files
+- ".github/ISSUE_TEMPLATE/config.yml"
+- ".github/ISSUE_TEMPLATE/issue-submission.yml"
+- ".github/pull_request_template.md"
+
+## What stays standardized
+- Required sections and order
+- Structured issue field shape
+- Review/testing checklist shape
+- Approval/workflow expectations
+
+## What is repo-specific here
+- Repo/property references
+- Context link target
+- Example copy and framing text tuned to 
+## Source
+- `TwoHoundStudios/bobgpt.com`

--- a/github/repo-hygiene-whitelabel/bobworldtour.com/.github/ISSUE_TEMPLATE/config.yml
+++ b/github/repo-hygiene-whitelabel/bobworldtour.com/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: General project context
+    url: https://github.com/TwoHoundStudios/bobworldtour.com/blob/main/README.md
+    about: Read the repo overview before filing broad or context-heavy requests.

--- a/github/repo-hygiene-whitelabel/bobworldtour.com/.github/ISSUE_TEMPLATE/issue-submission.yml
+++ b/github/repo-hygiene-whitelabel/bobworldtour.com/.github/ISSUE_TEMPLATE/issue-submission.yml
@@ -1,0 +1,93 @@
+name: Issue submission
+description: File a structured issue for content, design, UX, SEO, analytics, or site bugs.
+title: "[Issue]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing this. Please give enough context that someone can act on it without a long back-and-forth.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: What needs attention?
+      description: A short description of the problem, request, or idea.
+      placeholder: The homepage CTA should make the next trip/story/sign-up action more obvious.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: issue_type
+    attributes:
+      label: Issue type
+      description: Pick the closest fit.
+      options:
+        - Content update
+        - Design / layout
+        - Bug / broken behavior
+        - SEO / search visibility
+        - Analytics / tracking
+        - Feature request
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: page_url
+    attributes:
+      label: Affected page or file
+      description: Link the page URL or name the repo file/path if known.
+      placeholder: https://bobworldtour.com/ or index.html
+    validations:
+      required: true
+
+  - type: textarea
+    id: current_state
+    attributes:
+      label: What is happening now?
+      description: Describe the current behavior, content, or experience.
+      placeholder: Visitors can reach the page, but the main next action or missing content is not obvious.
+    validations:
+      required: true
+
+  - type: textarea
+    id: desired_state
+    attributes:
+      label: What should happen instead?
+      description: Describe the expected outcome.
+      placeholder: The page should steer visitors toward one clear next step and support the approved Bob World Tour direction.
+    validations:
+      required: true
+
+  - type: textarea
+    id: supporting_context
+    attributes:
+      label: Supporting context
+      description: Add screenshots, references, notes, audience context, or related links.
+      placeholder: Include examples, copy ideas, analytics notes, or linked issues.
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance criteria
+      description: How will we know this issue is complete?
+      placeholder: |
+        - The requested change is visible in the intended place
+        - Links and copy are correct
+        - The result matches the approved tone and direction
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - Nice to have
+        - Useful soon
+        - Important
+        - Urgent
+    validations:
+      required: true

--- a/github/repo-hygiene-whitelabel/bobworldtour.com/.github/pull_request_template.md
+++ b/github/repo-hygiene-whitelabel/bobworldtour.com/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## Summary
+- What changed?
+- Why was this change needed?
+
+## Testing / verification
+- [ ] I verified the change locally or in preview as appropriate
+- [ ] I captured the relevant evidence in the linked issue or PR body
+
+## Linked issue
+- Closes #4
+
+## Checklist
+- [ ] Scope stays tight to the linked issue
+- [ ] Copy, links, and paths were checked
+- [ ] No secrets or unrelated changes were introduced
+- [ ] Bob review/approval is still required before merge

--- a/github/repo-hygiene-whitelabel/bobworldtour.com/README.md
+++ b/github/repo-hygiene-whitelabel/bobworldtour.com/README.md
@@ -1,0 +1,23 @@
+# bobworldtour.com white-label GitHub templates
+
+This folder is a white-label copy of the standardized repo-hygiene templates for 
+auto-generated repo context: - source repo: 
+auto-fill below manually if needed.
+
+## Included files
+- ".github/ISSUE_TEMPLATE/config.yml"
+- ".github/ISSUE_TEMPLATE/issue-submission.yml"
+- ".github/pull_request_template.md"
+
+## What stays standardized
+- Required sections and order
+- Structured issue field shape
+- Review/testing checklist shape
+- Approval/workflow expectations
+
+## What is repo-specific here
+- Repo/property references
+- Context link target
+- Example copy and framing text tuned to 
+## Source
+- `TwoHoundStudios/bobworldtour.com`

--- a/github/repo-hygiene-whitelabel/nadba.com/.github/ISSUE_TEMPLATE/config.yml
+++ b/github/repo-hygiene-whitelabel/nadba.com/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: General project context
+    url: https://github.com/TwoHoundStudios/nadba.com/blob/main/README.md
+    about: Read the repo overview before filing broad or context-heavy requests.

--- a/github/repo-hygiene-whitelabel/nadba.com/.github/ISSUE_TEMPLATE/issue-submission.yml
+++ b/github/repo-hygiene-whitelabel/nadba.com/.github/ISSUE_TEMPLATE/issue-submission.yml
@@ -1,0 +1,93 @@
+name: Issue submission
+description: File a structured issue for content, design, UX, SEO, analytics, or site bugs.
+title: "[Issue]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing this. Please give enough context that someone can act on it without a long back-and-forth.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: What needs attention?
+      description: A short description of the problem, request, or idea.
+      placeholder: The homepage CTA should make the main membership, chapter, or next-step action more obvious.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: issue_type
+    attributes:
+      label: Issue type
+      description: Pick the closest fit.
+      options:
+        - Content update
+        - Design / layout
+        - Bug / broken behavior
+        - SEO / search visibility
+        - Analytics / tracking
+        - Feature request
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: page_url
+    attributes:
+      label: Affected page or file
+      description: Link the page URL or name the repo file/path if known.
+      placeholder: https://nadba.com/ or index.html
+    validations:
+      required: true
+
+  - type: textarea
+    id: current_state
+    attributes:
+      label: What is happening now?
+      description: Describe the current behavior, content, or experience.
+      placeholder: Visitors can reach the page, but the primary association action or missing content is not obvious.
+    validations:
+      required: true
+
+  - type: textarea
+    id: desired_state
+    attributes:
+      label: What should happen instead?
+      description: Describe the expected outcome.
+      placeholder: The page should steer visitors toward one clear next step and support the approved NADBA direction.
+    validations:
+      required: true
+
+  - type: textarea
+    id: supporting_context
+    attributes:
+      label: Supporting context
+      description: Add screenshots, references, notes, audience context, or related links.
+      placeholder: Include examples, copy ideas, analytics notes, or linked issues.
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance criteria
+      description: How will we know this issue is complete?
+      placeholder: |
+        - The requested change is visible in the intended place
+        - Links and copy are correct
+        - The result matches the approved tone and direction
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - Nice to have
+        - Useful soon
+        - Important
+        - Urgent
+    validations:
+      required: true

--- a/github/repo-hygiene-whitelabel/nadba.com/.github/pull_request_template.md
+++ b/github/repo-hygiene-whitelabel/nadba.com/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## Summary
+- What changed?
+- Why was this change needed?
+
+## Testing / verification
+- [ ] I verified the change locally or in preview as appropriate
+- [ ] I captured the relevant evidence in the linked issue or PR body
+
+## Linked issue
+- Closes #6
+
+## Checklist
+- [ ] Scope stays tight to the linked issue
+- [ ] Copy, links, and paths were checked
+- [ ] No secrets or unrelated changes were introduced
+- [ ] Bob review/approval is still required before merge

--- a/github/repo-hygiene-whitelabel/nadba.com/README.md
+++ b/github/repo-hygiene-whitelabel/nadba.com/README.md
@@ -1,0 +1,22 @@
+# nadba.com white-label GitHub templates
+
+This folder is a white-label copy of the standardized repo-hygiene templates for `nadba.com`.
+
+## Included files
+- `.github/ISSUE_TEMPLATE/config.yml`
+- `.github/ISSUE_TEMPLATE/issue-submission.yml`
+- `.github/pull_request_template.md`
+
+## What stays standardized
+- Required sections and order
+- Structured issue field shape
+- Review/testing checklist shape
+- Approval/workflow expectations
+
+## What is repo-specific here
+- Repo/property references
+- Context link target
+- Example copy and framing text tuned to `nadba.com`
+
+## Source
+- `TwoHoundStudios/nadba.com`

--- a/github/repo-hygiene-whitelabel/thekingofdns.com/.github/ISSUE_TEMPLATE/config.yml
+++ b/github/repo-hygiene-whitelabel/thekingofdns.com/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: General project context
+    url: https://github.com/TwoHoundStudios/thekingofdns.com/blob/main/README.md
+    about: Read the repo overview before filing broad or context-heavy requests.

--- a/github/repo-hygiene-whitelabel/thekingofdns.com/.github/ISSUE_TEMPLATE/issue-submission.yml
+++ b/github/repo-hygiene-whitelabel/thekingofdns.com/.github/ISSUE_TEMPLATE/issue-submission.yml
@@ -1,0 +1,93 @@
+name: Issue submission
+description: File a structured issue for content, design, UX, SEO, analytics, or site bugs.
+title: "[Issue]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing this. Please give enough context that someone can act on it without a long back-and-forth.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: What needs attention?
+      description: A short description of the problem, request, or idea.
+      placeholder: The homepage CTA should make consulting or booking more obvious.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: issue_type
+    attributes:
+      label: Issue type
+      description: Pick the closest fit.
+      options:
+        - Content update
+        - Design / layout
+        - Bug / broken behavior
+        - SEO / search visibility
+        - Analytics / tracking
+        - Feature request
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: page_url
+    attributes:
+      label: Affected page or file
+      description: Link the page URL or name the repo file/path if known.
+      placeholder: https://thekingofdns.com/ or index.html
+    validations:
+      required: true
+
+  - type: textarea
+    id: current_state
+    attributes:
+      label: What is happening now?
+      description: Describe the current behavior, content, or experience.
+      placeholder: Visitors can reach the page, but the main next action is not obvious.
+    validations:
+      required: true
+
+  - type: textarea
+    id: desired_state
+    attributes:
+      label: What should happen instead?
+      description: Describe the expected outcome.
+      placeholder: The page should steer visitors toward one clear consulting or booking action.
+    validations:
+      required: true
+
+  - type: textarea
+    id: supporting_context
+    attributes:
+      label: Supporting context
+      description: Add screenshots, references, notes, audience context, or related links.
+      placeholder: Include examples, copy ideas, analytics notes, or linked issues.
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance criteria
+      description: How will we know this issue is complete?
+      placeholder: |
+        - The requested change is visible in the intended place
+        - Links and copy are correct
+        - The result matches the approved tone and direction
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - Nice to have
+        - Useful soon
+        - Important
+        - Urgent
+    validations:
+      required: true

--- a/github/repo-hygiene-whitelabel/thekingofdns.com/.github/pull_request_template.md
+++ b/github/repo-hygiene-whitelabel/thekingofdns.com/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## Summary
+- What changed?
+- Why was this change needed?
+
+## Testing / verification
+- [ ] I verified the change locally or in preview as appropriate
+- [ ] I captured the relevant evidence in the linked issue or PR body
+
+## Linked issue
+- Closes #6
+
+## Checklist
+- [ ] Scope stays tight to the linked issue
+- [ ] Copy, links, and paths were checked
+- [ ] No secrets or unrelated changes were introduced
+- [ ] Bob review/approval is still required before merge

--- a/github/repo-hygiene-whitelabel/thekingofdns.com/README.md
+++ b/github/repo-hygiene-whitelabel/thekingofdns.com/README.md
@@ -1,0 +1,23 @@
+# thekingofdns.com white-label GitHub templates
+
+This folder is a white-label copy of the standardized repo-hygiene templates for 
+auto-generated repo context: - source repo: 
+auto-fill below manually if needed.
+
+## Included files
+- ".github/ISSUE_TEMPLATE/config.yml"
+- ".github/ISSUE_TEMPLATE/issue-submission.yml"
+- ".github/pull_request_template.md"
+
+## What stays standardized
+- Required sections and order
+- Structured issue field shape
+- Review/testing checklist shape
+- Approval/workflow expectations
+
+## What is repo-specific here
+- Repo/property references
+- Context link target
+- Example copy and framing text tuned to 
+## Source
+- `TwoHoundStudios/thekingofdns.com`


### PR DESCRIPTION
## Summary
- add the first white-label GitHub template set for `bobeckert.com`
- copy the standardized issue + PR template files into the templates repo
- document what stays standardized vs what is repo-specific

## Testing
- copied files directly from `bobeckert/bobeckert.com`
- verified the folder contains config, issue submission, PR template, and README